### PR TITLE
rubocopの設定の相対パス設定を外す

### DIFF
--- a/config/.rubocop.yml
+++ b/config/.rubocop.yml
@@ -3,8 +3,8 @@ AllCops:
   # TargetRubyVersion: x.x
   # TargetRailsVersion: x.x
   Exclude:
-    - './db/schema.rb'
-    - './db/migrate/**/*'
+    - 'db/schema.rb'
+    - 'db/migrate/**/*'
 
 Rails:
   Enabled: true


### PR DESCRIPTION
SideCIに問い合わせた内容：
> RuboCop のドキュメントには

> In .rubocop.yml and any other configuration file beginning with .rubocop, files and directories are specified relative to the directory where the configuration file is. In configuration files that don't begin with .rubocop, e.g. our_company_defaults.yml, paths are relative to the directory where rubocop is run.

>と記述されています。継承元のgemの設定ファイル名が .rubocop.yml であり、その設定ファイルにおけるexcludeが相対パス指定になっているために、そのファイルがあるディレクトリ、つまりgem側の dm_linters/config/ ディレクトリを起点にした相対指定でRuboCopが実行されている可能性があります。

> そこで、
> 1. './db/schema.rb' のような指定を 'db/schema.rb' にような指定に変更する
> 2. 1だけではダメだった場合、1の指定のままファイル名を .rubocop で始まらない名前にリネームする
等をお試しいただければと思います。RuboCopのinclude, exclude の指定については下記ドキュメントをご覧いただければと思います。
https://github.com/bbatsov/rubocop/blob/master/manual/configuration.md#includingexcluding-files


### 先に１番のやり方で対応してみます。
