### PR TITLE
exclude scenario for metrics/blocklength

### DIFF
--- a/config/.rubocop.yml
+++ b/config/.rubocop.yml
@@ -39,8 +39,7 @@ Metrics/BlockLength:
     - feature
     - context
     - shared_context
-  Exclude:
-    - 'spec/**/*'
+    - scenario
 
 Metrics/BlockNesting:
   CountBlocks: false

--- a/config/.rubocop.yml
+++ b/config/.rubocop.yml
@@ -39,6 +39,8 @@ Metrics/BlockLength:
     - feature
     - context
     - shared_context
+  Exclude:
+    - 'spec/**/*'
 
 Metrics/BlockNesting:
   CountBlocks: false

--- a/lib/dm_linters/version.rb
+++ b/lib/dm_linters/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DmLinters
-  VERSION = '0.0.5'.freeze
+  VERSION = '0.0.6'.freeze
 end


### PR DESCRIPTION
`spec` 配下のファイルは`metrics/blocklength` をチェックしないようにする。

参照：
* https://stackoverflow.com/questions/40934345/rubocop-25-line-block-size-and-rspec-tests
* https://qiita.com/QUANON/items/65a420e35af455aad74c